### PR TITLE
Fixes to Select component

### DIFF
--- a/components/Select/README.md
+++ b/components/Select/README.md
@@ -4,8 +4,8 @@
 
 ```html
 <m-select v-model="selected">
-    <m-select-option id="11">A</m-select-option>
-    <m-select-option id="33">B</m-select-option>
+    <m-select-option slot="options" id="11">A</m-select-option>
+    <m-select-option slot="options" id="33">B</m-select-option>
 </m-select>
 
 <m-select-multi v-model="selectedMulti" :size="4">

--- a/components/Select/Select.vue
+++ b/components/Select/Select.vue
@@ -1,11 +1,11 @@
 <template>
-    <div class="mdc-select" tabindex="0" :aria-disabled="disabled" role="listbox" @MDCSelect:change="onChange">
-      <div class="mdc-select__surface" ref="surface">
+    <div class="mdc-select" ref="surface" tabindex="0" :aria-disabled="disabled" role="listbox" @MDCSelect:change="onChange">
+      <div class="mdc-select__surface" tabindex="0">
         <div class="mdc-select__label">
           <slot />
           </div>
         <div class="mdc-select__selected-text" />
-        <div class="mdc-select__bottom-line" />  
+        <div class="mdc-select__bottom-line" />
       </div>
       <div class="mdc-simple-menu mdc-select__menu">
         <ul class="mdc-list mdc-simple-menu__items">


### PR DESCRIPTION
I've found another issue, this time with the Select component. Two things to note:

1. The ref="surface" was being used on the wrong element. As per the API, it should be used on the top div
2. The documentation is also incomplete on how to use `<m-select>` and `<m-select-option>`. Given that there's a named slot "options" in the parent, when using `<m-select-option>` we need to state the name of that slot or the content won't be added correctly.