### PR TITLE
Feat: better integration with IntelliJ IDEA-based IDEs

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-button', Button)
+  install (Vue) {
+    Vue.component('m-button', Button)
   }
 }
 export default plugin

--- a/components/card/index.js
+++ b/components/card/index.js
@@ -5,9 +5,9 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-card', Card)
-    vm.component('m-card-media', CardMedia)
+  install (Vue) {
+    Vue.component('m-card', Card)
+    Vue.component('m-card-media', CardMedia)
   }
 }
 export default plugin

--- a/components/checkbox/index.js
+++ b/components/checkbox/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-checkbox', Checkbox)
+  install (Vue) {
+    Vue.component('m-checkbox', Checkbox)
   }
 }
 export default plugin

--- a/components/chips/index.js
+++ b/components/chips/index.js
@@ -5,9 +5,9 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-chip', Chip)
-    vm.component('m-chip-set', ChipSet)
+  install (Vue) {
+    Vue.component('m-chip', Chip)
+    Vue.component('m-chip-set', ChipSet)
   }
 }
 export default plugin

--- a/components/dialog/index.js
+++ b/components/dialog/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-dialog', Dialog)
+  install (Vue) {
+    Vue.component('m-dialog', Dialog)
   }
 }
 export default plugin

--- a/components/drawer/index.js
+++ b/components/drawer/index.js
@@ -9,13 +9,13 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-drawer-content', DrawerContent)
-    vm.component('m-drawer-header', DrawerHeader)
-    vm.component('m-drawer', Drawer)
-    vm.component('m-drawer-scrim', DrawerScrim)
-    vm.component('m-drawer-app-content', DrawerAppContent)
-    vm.component('m-drawer-list', DrawerList)
+  install (Vue) {
+    Vue.component('m-drawer-content', DrawerContent)
+    Vue.component('m-drawer-header', DrawerHeader)
+    Vue.component('m-drawer', Drawer)
+    Vue.component('m-drawer-scrim', DrawerScrim)
+    Vue.component('m-drawer-app-content', DrawerAppContent)
+    Vue.component('m-drawer-list', DrawerList)
   }
 }
 export default plugin

--- a/components/elevation/index.js
+++ b/components/elevation/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-elevation', Elevation)
+  install (Vue) {
+    Vue.component('m-elevation', Elevation)
   }
 }
 export default plugin

--- a/components/fab/index.js
+++ b/components/fab/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-fab', Fab)
+  install (Vue) {
+    Vue.component('m-fab', Fab)
   }
 }
 export default plugin

--- a/components/floating-label/index.js
+++ b/components/floating-label/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-floating-label', FloatingLabel)
+  install (Vue) {
+    Vue.component('m-floating-label', FloatingLabel)
   }
 }
 export default plugin

--- a/components/form-field/index.js
+++ b/components/form-field/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-form-field', FormField)
+  install (Vue) {
+    Vue.component('m-form-field', FormField)
   }
 }
 export default plugin

--- a/components/grid-list/index.js
+++ b/components/grid-list/index.js
@@ -5,9 +5,9 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-grid-list', GridList)
-    vm.component('m-grid-tile', GridListTile)
+  install (Vue) {
+    Vue.component('m-grid-list', GridList)
+    Vue.component('m-grid-tile', GridListTile)
   }
 }
 export default plugin

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-icon-button', IconButton)
+  install (Vue) {
+    Vue.component('m-icon-button', IconButton)
   }
 }
 export default plugin

--- a/components/icon/index.js
+++ b/components/icon/index.js
@@ -3,8 +3,8 @@ import Icon from './Icon.vue'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-icon', Icon)
+  install (Vue) {
+    Vue.component('m-icon', Icon)
   }
 }
 export default plugin

--- a/components/image-list/index.js
+++ b/components/image-list/index.js
@@ -4,9 +4,9 @@ import ImageListItem from './ImageListItem.vue'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-image-list', ImageList)
-    vm.component('m-image-list-item', ImageListItem)
+  install (Vue) {
+    Vue.component('m-image-list', ImageList)
+    Vue.component('m-image-list-item', ImageListItem)
   }
 }
 export default plugin

--- a/components/layout-grid/index.js
+++ b/components/layout-grid/index.js
@@ -6,10 +6,10 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-layout-grid', LayoutGrid)
-    vm.component('m-layout-grid-cell', LayoutGridCell)
-    vm.component('m-layout-grid-inner', LayoutGridInner)
+  install (Vue) {
+    Vue.component('m-layout-grid', LayoutGrid)
+    Vue.component('m-layout-grid-cell', LayoutGridCell)
+    Vue.component('m-layout-grid-inner', LayoutGridInner)
   }
 }
 export default plugin

--- a/components/line-ripple/index.js
+++ b/components/line-ripple/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-line-ripple', LineRipple)
+  install (Vue) {
+    Vue.component('m-line-ripple', LineRipple)
   }
 }
 export default plugin

--- a/components/linear-progress/index.js
+++ b/components/linear-progress/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-linear-progress', LinearProgress)
+  install (Vue) {
+    Vue.component('m-linear-progress', LinearProgress)
   }
 }
 export default plugin

--- a/components/list/index.js
+++ b/components/list/index.js
@@ -9,13 +9,13 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-list', List)
-    vm.component('m-list-divider', ListDivider)
-    vm.component('m-list-group', ListGroup)
-    vm.component('m-list-group-divider', ListGroupDivider)
-    vm.component('m-list-group-subheader', ListGroupSubheader)
-    vm.component('m-list-item', ListItem)
+  install (Vue) {
+    Vue.component('m-list', List)
+    Vue.component('m-list-divider', ListDivider)
+    Vue.component('m-list-group', ListGroup)
+    Vue.component('m-list-group-divider', ListGroupDivider)
+    Vue.component('m-list-group-subheader', ListGroupSubheader)
+    Vue.component('m-list-item', ListItem)
   }
 }
 export default plugin

--- a/components/menu/index.js
+++ b/components/menu/index.js
@@ -6,10 +6,10 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-menu', Menu)
-    vm.component('m-menu-anchor', MenuAnchor)
-    vm.component('m-menu-surface', MenuSurface)
+  install (Vue) {
+    Vue.component('m-menu', Menu)
+    Vue.component('m-menu-anchor', MenuAnchor)
+    Vue.component('m-menu-surface', MenuSurface)
   }
 }
 export default plugin

--- a/components/notched-outline/index.js
+++ b/components/notched-outline/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-notched-outline', NotchedOutline)
+  install (Vue) {
+    Vue.component('m-notched-outline', NotchedOutline)
   }
 }
 export default plugin

--- a/components/radio/index.js
+++ b/components/radio/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-radio', Radio)
+  install (Vue) {
+    Vue.component('m-radio', Radio)
   }
 }
 export default plugin

--- a/components/ripple/index.js
+++ b/components/ripple/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-ripple', Ripple)
+  install (Vue) {
+    Vue.component('m-ripple', Ripple)
   }
 }
 export default plugin

--- a/components/select/index.js
+++ b/components/select/index.js
@@ -5,9 +5,9 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-select', Select)
-    vm.component('m-select-helper-text', SelectHelperText)
+  install (Vue) {
+    Vue.component('m-select', Select)
+    Vue.component('m-select-helper-text', SelectHelperText)
   }
 }
 export default plugin

--- a/components/shape/index.js
+++ b/components/shape/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-shape', Shape)
+  install (Vue) {
+    Vue.component('m-shape', Shape)
   }
 }
 export default plugin

--- a/components/slider/index.js
+++ b/components/slider/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-slider', Slider)
+  install (Vue) {
+    Vue.component('m-slider', Slider)
   }
 }
 export default plugin

--- a/components/snackbar/index.js
+++ b/components/snackbar/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-snackbar', Snackbar)
+  install (Vue) {
+    Vue.component('m-snackbar', Snackbar)
   }
 }
 export default plugin

--- a/components/switch/index.js
+++ b/components/switch/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-switch', Switch)
+  install (Vue) {
+    Vue.component('m-switch', Switch)
   }
 }
 export default plugin

--- a/components/tabs/index.js
+++ b/components/tabs/index.js
@@ -7,11 +7,11 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-tab', Tab)
-    vm.component('m-tab-bar', TabBar)
-    vm.component('m-tab-indicator', TabIndicator)
-    vm.component('m-tab-scroller', TabScroller)
+  install (Vue) {
+    Vue.component('m-tab', Tab)
+    Vue.component('m-tab-bar', TabBar)
+    Vue.component('m-tab-indicator', TabIndicator)
+    Vue.component('m-tab-scroller', TabScroller)
   }
 }
 export default plugin

--- a/components/text-field/index.js
+++ b/components/text-field/index.js
@@ -5,9 +5,9 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-text-field', TextField)
-    vm.component('m-text-field-helper-text', TextFieldHelperText)
+  install (Vue) {
+    Vue.component('m-text-field', TextField)
+    Vue.component('m-text-field-helper-text', TextFieldHelperText)
   }
 }
 export default plugin

--- a/components/theme/index.js
+++ b/components/theme/index.js
@@ -4,8 +4,8 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-theme', Theme)
+  install (Vue) {
+    Vue.component('m-theme', Theme)
   }
 }
 export default plugin

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -7,11 +7,11 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-toolbar', Toolbar)
-    vm.component('m-toolbar-fixed-adjust', ToolbarFixedAdjust)
-    vm.component('m-toolbar-icon', ToolbarIcon)
-    vm.component('m-toolbar-row', ToolbarRow)
+  install (Vue) {
+    Vue.component('m-toolbar', Toolbar)
+    Vue.component('m-toolbar-fixed-adjust', ToolbarFixedAdjust)
+    Vue.component('m-toolbar-icon', ToolbarIcon)
+    Vue.component('m-toolbar-row', ToolbarRow)
   }
 }
 export default plugin

--- a/components/top-app-bar/index.js
+++ b/components/top-app-bar/index.js
@@ -5,9 +5,9 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-top-app-bar', TopAppBar)
-    vm.component('m-top-app-bar-fixed-adjust', TopAppBarFixedAdjust)
+  install (Vue) {
+    Vue.component('m-top-app-bar', TopAppBar)
+    Vue.component('m-top-app-bar-fixed-adjust', TopAppBarFixedAdjust)
   }
 }
 export default plugin

--- a/components/typography/index.js
+++ b/components/typography/index.js
@@ -10,14 +10,14 @@ import './styles.scss'
 import { initPlugin } from '../'
 
 const plugin = {
-  install (vm) {
-    vm.component('m-typo-body', Body)
-    vm.component('m-typo-button', Button)
-    vm.component('m-typo-caption', Caption)
-    vm.component('m-typo-headline', Headline)
-    vm.component('m-typo-overline', Overline)
-    vm.component('m-typo-subheading', Subheading)
-    vm.component('m-typography', Typography)
+  install (Vue) {
+    Vue.component('m-typo-body', Body)
+    Vue.component('m-typo-button', Button)
+    Vue.component('m-typo-caption', Caption)
+    Vue.component('m-typo-headline', Headline)
+    Vue.component('m-typo-overline', Overline)
+    Vue.component('m-typo-subheading', Subheading)
+    Vue.component('m-typography', Typography)
   }
 }
 export default plugin


### PR DESCRIPTION
Change
```js
  install (vm) {
    vm.component('m-button', Button)
  }
```
to
```js
  install (Vue) {
    Vue.component('m-button', Button)
  }
```

## What's the difference?

IntelliJ IDEA-based IDEs complains 'Unknown html tag' in the previous install style. It seems that the Vue.js plugin only detects the components in `Vue.component()`