### PR TITLE
Fix(snackbar): labelText is empty when using default slot as the labal text

### DIFF
--- a/components/snackbar/Snackbar.vue
+++ b/components/snackbar/Snackbar.vue
@@ -113,7 +113,7 @@ export default {
       this.mdcSnackbar.actionButtonText = this.actionButtonText
     },
     labelText () {
-      this.mdcSnackbar.labelText = this.labelText
+      if (this.labelText && this.labelText !== '') this.mdcSnackbar.labelText = this.labelText
     },
     closeOnEscape () {
       this.mdcSnackbar.closeOnEscape = this.closeOnEscape
@@ -126,7 +126,7 @@ export default {
     this.mdcSnackbar = MDCSnackbar.attachTo(this.$el)
     this.mdcSnackbar.timeoutMs = this.timeoutMs
     this.mdcSnackbar.closeOnEscape = this.closeOnEscape
-    this.mdcSnackbar.labelText = this.labelText
+    if (this.labelText && this.labelText !== '') this.mdcSnackbar.labelText = this.labelText
     this.mdcSnackbar.actionButtonText = this.actionButtonText
   },
   beforeDestroy () {


### PR DESCRIPTION
https://codepen.io/chankcccc/pen/EzWwGN

Although users can choose either the labelText prop or default slot to place the label text. It's recommended to use only one of this at a time.