### PR TITLE
Feat(select): add select icon

### DIFF
--- a/components/select/Select.vue
+++ b/components/select/Select.vue
@@ -4,6 +4,7 @@
     class="mdc-select"
     @MDCSelect:change="onChange"
   >
+    <slot name="leadingIcon"/>
     <input
       v-if="enhanced && name"
       :name="name"
@@ -127,7 +128,8 @@ export default {
     classes () {
       return {
         'mdc-select--disabled': this.disabled,
-        'mdc-select--outlined': this.outlined
+        'mdc-select--outlined': this.outlined,
+        'mdc-select--with-leading-icon': this.$slots.leadingIcon
       }
     },
     ariaLabelledby () {

--- a/components/select/SelectIcon.vue
+++ b/components/select/SelectIcon.vue
@@ -1,0 +1,53 @@
+<template>
+  <i
+    class="mdc-select__icon"
+    v-bind="attrs"
+    v-on="$listeners"
+  >
+    <slot/>
+  </i>
+</template>
+
+<script>
+import { MDCSelectIcon } from '@material/select/icon'
+import { baseComponentMixin, themeClassMixin } from '../base'
+
+export default {
+  name: 'SelectIcon',
+  mixins: [baseComponentMixin, themeClassMixin],
+  props: {
+    clickable: {
+      type: Boolean,
+      default: true
+    }
+  },
+  data () {
+    return {
+      attrs: this.$attrs,
+      mdcSelectIcon: undefined
+    }
+  },
+  watch: {
+    clickable () {
+      if (this.clickable) {
+        this.$set(this.attrs, 'tabindex', '0')
+        this.$set(this.attrs, 'role', 'button')
+      } else {
+        this.$delete(this.attrs, 'tabindex')
+        this.$delete(this.attrs, 'role')
+      }
+    }
+  },
+  mounted () {
+    if (this.clickable) {
+      this.$set(this.attrs, 'tabindex', '0')
+      this.$set(this.attrs, 'role', 'button')
+    }
+    this.mdcSelectIcon = MDCSelectIcon.attachTo(this.$el)
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/components/select/index.js
+++ b/components/select/index.js
@@ -1,5 +1,6 @@
 import Select from './Select.vue'
 import SelectHelperText from './SelectHelperText.vue'
+import SelectIcon from './SelectIcon'
 import './styles.scss'
 
 import { initPlugin } from '../'
@@ -8,6 +9,7 @@ const plugin = {
   install (vm) {
     vm.component('m-select', Select)
     vm.component('m-select-helper-text', SelectHelperText)
+    vm.component('m-select-icon', SelectIcon)
   }
 }
 export default plugin

--- a/docs/.vuepress/components/SelectIconDemo.vue
+++ b/docs/.vuepress/components/SelectIconDemo.vue
@@ -1,0 +1,54 @@
+<template>
+    <div>
+        <ComponentSection flex-direction="column">
+            <m-typography>Filled</m-typography>
+            <m-select :disabled="checkboxProps[0].value" :required="checkboxProps[1].value"
+                      :valid="checkboxProps[2].value" id="select_demo">
+                <m-select-icon :clickable="checkboxProps[3].value" class="material-icons" slot="leadingIcon">search</m-select-icon>
+                <template slot="default">
+                    <option value="apple">Apple</option>
+                    <option value="orange">Orange</option>
+                    <option value="banana">Banana</option>
+                </template>
+                <m-floating-label for="select_demo" id="select_demo_label" slot="label">Fruit</m-floating-label>
+                <m-line-ripple slot="line"/>
+            </m-select>
+            <m-typography>Outlined</m-typography>
+            <m-select :disabled="checkboxProps[0].value" :required="checkboxProps[1].value"
+                      :valid="checkboxProps[2].value" id="select_demo2" outlined>
+                <m-select-icon :clickable="checkboxProps[3].value" class="material-icons" slot="leadingIcon">search</m-select-icon>
+                <template slot="default">
+                    <option value="apple">Apple</option>
+                    <option value="orange">Orange</option>
+                    <option value="banana">Banana</option>
+                </template>
+                <m-floating-label for="select_demo2" id="select_demo2_label" slot="label">Fruit</m-floating-label>
+                <m-line-ripple slot="line"/>
+            </m-select>
+        </ComponentSection>
+        <ComponentProps
+                :checkboxProps="checkboxProps"
+                :radioProps="radioProps"/>
+    </div>
+</template>
+
+<script>
+  export default {
+    name: 'SelectDemo',
+    data () {
+      return {
+        radioProps: [],
+        checkboxProps: [
+          { prop: 'disabled', value: false },
+          { prop: 'required', value: false },
+          { prop: 'valid', value: true },
+          { prop: 'clickable', value: false}
+        ]
+      }
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -90,6 +90,10 @@ The demonstration in this page is a work in progress..
 
 <SelectHelperTextDemo/>
 
+## Select Icon
+
+<SelectIconDemo/>
+
 ## Slider
 
 <SliderDemo/>


### PR DESCRIPTION
There's a problem here. The usage
```html
<m-select-icon class="material-icons">search</m-select-icon>
```
is quite different from those in Icon Button.

Should we change icon button to make them more consistent?