### PR TITLE
docs(select): add end tag to <m-floating-label>

### DIFF
--- a/components/select/README.md
+++ b/components/select/README.md
@@ -24,6 +24,7 @@
   <m-floating-label
     slot="label">
     Pick a food group
+  </m-floating-label>
   <m-notched-outline slot="line"/>
 </m-select>
 ```


### PR DESCRIPTION
Fix a tiny bug in `README.md`.