### PR TITLE
fix(floating-label): make classes responsive

### DIFF
--- a/components/floating-label/FloatingLabel.vue
+++ b/components/floating-label/FloatingLabel.vue
@@ -45,10 +45,10 @@ export default {
   },
   watch: {
     floatAbove () {
-      this.classes['mdc-floating-label--float-above'] = this.floatAbove
+      this.$set(this.classes, 'mdc-floating-label--float-above', this.floatAbove)
     },
     shake () {
-      this.classes['mdc-floating-label--shake'] = this.shake
+      this.$set(this.classes, 'mdc-floating-label--shake', this.shake)
     }
   },
   mounted () {

--- a/components/floating-label/FloatingLabel.vue
+++ b/components/floating-label/FloatingLabel.vue
@@ -36,15 +36,19 @@ export default {
   },
   data () {
     return {
-      mdcFloatingLabel: undefined
-    }
-  },
-  computed: {
-    classes () {
-      return {
+      mdcFloatingLabel: undefined,
+      classes: {
         'mdc-floating-label--float-above': this.floatAbove,
         'mdc-floating-label--shake': this.shake
       }
+    }
+  },
+  watch: {
+    floatAbove () {
+      this.classes['mdc-floating-label--float-above'] = this.floatAbove
+    },
+    shake () {
+      this.classes['mdc-floating-label--shake'] = this.shake
     }
   },
   mounted () {


### PR DESCRIPTION
Use data and watchers instead of computed property to make classes of floating label responsive to changes of props.