### PR TITLE
[List] Prevent accessing selectedIndex when this.mdcList is undefined

### DIFF
--- a/components/list/List.vue
+++ b/components/list/List.vue
@@ -176,7 +176,9 @@ export default {
       }
     },
     onAction (e) {
-      this.$emit('change', this.mdcList.selectedIndex)
+      if (this.mdcList) {
+        this.$emit('change', this.mdcList.selectedIndex)
+      }
       this.$emit('action', e.detail)
     }
   }


### PR DESCRIPTION
When using `<m-list :js="false">`, a JavaScript error occurred because `this.mdcList` is undefined.