### PR TITLE
fix(icon-button): update icon button components

### DIFF
--- a/components/card/__test__/__snapshots__/Card.spec.js.snap
+++ b/components/card/__test__/__snapshots__/Card.spec.js.snap
@@ -39,13 +39,9 @@ exports[`Card should render with action icons 1`] = `
   <div class="mdc-card__actions">
     <!---->
     <!---->
-    <div class="mdc-card__action-icons"><button data-toggle-on-content="" data-toggle-on-label="" data-toggle-on-class="" data-toggle-off-content="" data-toggle-off-label="" data-toggle-off-class="" class="mdc-icon-button mdc-card__action mdc-card__action--icon">
+    <div class="mdc-card__action-icons"><button class="mdc-icon-button mdc-ripple-upgraded--unbounded mdc-card__action mdc-card__action--icon">
         <!---->
-        <!---->
-        <!---->
-        <!----></button><button data-toggle-on-content="" data-toggle-on-label="" data-toggle-on-class="" data-toggle-off-content="" data-toggle-off-label="" data-toggle-off-class="" class="mdc-icon-button mdc-card__action mdc-card__action--icon">
-        <!---->
-        <!---->
+        <!----></button><button class="mdc-icon-button mdc-ripple-upgraded--unbounded mdc-card__action mdc-card__action--icon">
         <!---->
         <!----></button></div>
   </div>

--- a/components/icon-button/README.md
+++ b/components/icon-button/README.md
@@ -5,6 +5,8 @@ e.g. SVGs. When you want to use toggling props you have to provide CSS for your 
 
 ### Markup
 
+#### Using SVG
+
 ```html
 <m-icon-button>
   <svg>...</svg>
@@ -13,6 +15,30 @@ e.g. SVGs. When you want to use toggling props you have to provide CSS for your 
 <m-icon-button v-model="iconToggle">
   <svg slot="toggleOn">...</svg>
   <svg slot="toggleOff">...</svg>
+</m-icon-button>
+```
+
+#### Using Material Icons
+
+```html
+<m-icon-button icon="favorite"></m-icon-button>
+
+<m-icon-button v-model="iconToggle">
+  <m-icon slot="toggleOn">favorite</m-icon>
+  <m-icon slot="toggleOff">favorite_border</m-icon>
+</m-icon-button>
+```
+
+#### Using Font Awesome
+
+```html
+<m-icon-button>
+  <i class="fas fa-camera"></i>
+</m-icon-button>
+
+<m-icon-button v-model="iconToggle">
+  <i class="fas fa-check-circle" slot="toggleOn"></i>
+  <i class="far fa-check-circle" slot="toggleOff"></i>
 </m-icon-button>
 ```
 
@@ -30,13 +56,11 @@ data() {
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| toggleOnContent | String | ' ' | toggle icon name for 'on' state |
-| toggleOnLabel | String | ' ' | toggle icon label for 'on' state |
-| toggleOnClass | String | ' ' | toggle icon CSS class for 'on' state |
-| toggleOffContent | String | ' ' | toggle icon name for 'off' state |
-| toggleOffLabel | String | ' ' | toggle icon label for 'off' state |
-| toggleOffClass | String | ' ' | toggle icon CSS class for 'off' state |
 | value | Boolean | false | toggle state (could be v-modeled) |
+| href | String | '' | render as `<a>` if presented. Not recommended to use in icon button toggle |
+| icon | String | '' | Material Icon name. Similar to `icon` in `<m-icon>`. Omit this if you're using other icon libraries. |
+| ripple | Boolean | true | Whether to use js ripple or not. Notice that the icon button toggle always has a ripple so this prop is always omitted if `toggleOn` and `toggleOff` slots are presented. |
+| unbounded | Boolean | true | The `unbounded` prop of the ripple. |
 
 Non prop attributes and events are mapped to the inner button element.
 
@@ -44,7 +68,7 @@ Non prop attributes and events are mapped to the inner button element.
 
 | Slot | Description |
 |------|-------------|
-| default | button icon (will overrule all other slots if set) |
+| default | button icon |
 | toggleOn | toggle icon for 'on' state |
 | toggleOff | toggle icon for 'off' state |
 

--- a/components/icon-button/__tests__/__snapshots__/IconButton.spec.js.snap
+++ b/components/icon-button/__tests__/__snapshots__/IconButton.spec.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IconButton should render with no prop 1`] = `
-<button data-toggle-on-content="" data-toggle-on-label="" data-toggle-on-class="" data-toggle-off-content="" data-toggle-off-label="" data-toggle-off-class="" class="mdc-icon-button">
-  <!---->
-  <!---->
+<button class="mdc-icon-button mdc-ripple-upgraded--unbounded">
   <!---->
   <!----></button>
 `;

--- a/docs/.vuepress/components/IconButtonDemo.vue
+++ b/docs/.vuepress/components/IconButtonDemo.vue
@@ -1,19 +1,24 @@
 <template>
 <div>
   <ComponentSection>
-    <m-icon-button v-model="toggleData">
-      <!-- <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-        <path fill="none" d="M0 0h24v24H0z"/>
-        <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
-      </svg> -->
-      <svg slot="toggleOn" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <m-icon-button v-model="toggleData" :icon="radioProps[2].value ? 'favorite' : ''" :ripple="checkboxProps[0].value" :unbounded="checkboxProps[1].value">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" v-if="radioProps[0].value">
         <path fill="none" d="M0 0h24v24H0z"/>
         <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
       </svg>
-      <svg slot="toggleOff" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+      <svg slot="toggleOn" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" v-if="radioProps[1].value">
+        <path fill="none" d="M0 0h24v24H0z"/>
+        <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+      </svg>
+      <svg slot="toggleOff" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" v-if="radioProps[1].value">
         <path d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"/>
         <path d="M0 0h24v24H0z" fill="none"/>
       </svg>
+      <m-icon slot="toggleOn" icon="favorite" v-if="radioProps[3].value"></m-icon>
+      <m-icon slot="toggleOff" icon="favorite_border" v-if="radioProps[3].value"></m-icon>
+      <i class="fas fa-camera" slot="default" v-if="radioProps[4].value"></i>
+      <i class="fas fa-check-circle" slot="toggleOn" v-if="radioProps[5].value"></i>
+      <i class="far fa-check-circle" slot="toggleOff" v-if="radioProps[5].value"></i>
     </m-icon-button>
 
   </ComponentSection>
@@ -29,10 +34,18 @@ export default {
     return {
       toggleData: false,
       radioProps: [
+        { prop: 'basic (svg)', value: true },
+        { prop: 'toggle (svg)', value: false },
+        { prop: 'basic (material icons)', value: false },
+        { prop: 'toggle (material icons)', value: false },
+        { prop: 'basic (font awesome)', value: false },
+        { prop: 'toggle (font awesome)', value: false }
       ],
       checkboxProps: [
+        { prop: 'ripple', value: true },
+        { prop: 'unbounded', value: true }
       ]
     }
-  } 
+  }
 }
 </script>

--- a/docs/.vuepress/styles.scss
+++ b/docs/.vuepress/styles.scss
@@ -1,6 +1,10 @@
 $mdc-theme-primary: #5e35b1;
 $mdc-theme-secondary: #ff5722;
 $mdc-theme-background: #ffffff;
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
+@import "~@fortawesome/fontawesome-free/scss/fontawesome";
+@import "~@fortawesome/fontawesome-free/scss/solid";
+@import "~@fortawesome/fontawesome-free/scss/regular";
 
 @import "../../components/theme/styles";
 @import "../../components/typography/styles";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3608,6 +3608,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.0.tgz",
+      "integrity": "sha512-vKDJUuE2GAdBERaQWmmtsciAMzjwNrROXA5KTGSZvayAsmuTGjam5z6QNqNPCwDfVljLWuov1nEC3mEQf/n6fQ==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/plugin-proposal-object-rest-spread": "7.8.3",
     "@babel/plugin-transform-object-assign": "7.8.3",
     "@babel/preset-env": "7.8.4",
+    "@fortawesome/fontawesome-free": "^5.12.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
@@ -81,8 +82,8 @@
     "url-loader": "3.0.0",
     "vue-jest": "3.0.5",
     "vue-loader": "15.7.2",
-    "webpack": "4.41.5",
     "vuepress": "1.3.0",
+    "webpack": "4.41.5",
     "webpack-cli": "3.3.10",
     "webpack-dev-server": "3.10.2",
     "webpack-merge": "4.2.2"


### PR DESCRIPTION
Make the ripple optional.
Make all of the props reactive.
Add Font Awesome to show demos using different icon libraries.

BREAKING CHANGE: `data-toggle-*` are deprecated since `1.0.0` in mdc-web. All associated props are removed. To have an icon button toggle, use `toggleOn` and `toggleOff` slots instead.

fixes #531 